### PR TITLE
vee7: Use 2 threads for dex2oat

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -67,3 +67,6 @@ dalvik.vm.dex2oat-Xmx=96m
 dalvik.vm.image-dex2oat-Xms=48m
 dalvik.vm.image-dex2oat-Xmx=48m
 ro.ksm.default=1
+
+# use 2 threads max for dex2oat
+ro.sys.fw.dex2oat_thread_count=2


### PR DESCRIPTION
- Attempting to reduce the impact of a long dexopt on this poor device.
